### PR TITLE
Fixes to get this to actually install.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
-include james.py
+recursive-include cah *.py
 include LICENSE
-include README
+include README.md
 include requirements.txt
 include setup.py

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-james.py - Chief CLI.
+Card Against Hamper - An IRC game.
 
 INSTALL
 =======

--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,10 @@ with open('requirements.txt') as f:
 setup(
     name='cah',
     version='0.1',
-    modules=['cah'],
-    scripts=['cah/cah.py'],
+    packages=['cah'],
     author='Dean Johnson',
     author_email='deanjohnson222@gmail.com',
     url='https://github.com/johnsdea/cah_bot',
     install_requires=requirements,
-    package_data={'cah': ['requirements.txt', 'README', 'LICENSE']}
+    package_data={'cah': ['requirements.txt', 'README.md', 'LICENSE']}
 )


### PR DESCRIPTION
With these changes I was able to pip install it into my hamper and reference it as 

``` yaml
plugins:
    - cah/cah
```

I didn't actually test if it ran.

:wolf: 
